### PR TITLE
Add initial support for tags

### DIFF
--- a/src/main/kotlin/me/kpavlov/mocks/statsd/server/Metric.kt
+++ b/src/main/kotlin/me/kpavlov/mocks/statsd/server/Metric.kt
@@ -56,7 +56,7 @@ internal interface Metric {
             return value.elementAtOrElse(0) { 0.0 }
         }
 
-        fun values(): Array<Double> = value.toTypedArray()
+        fun values(): DoubleArray = value.toDoubleArray()
     }
 }
 

--- a/src/main/kotlin/me/kpavlov/mocks/statsd/server/MetricId.kt
+++ b/src/main/kotlin/me/kpavlov/mocks/statsd/server/MetricId.kt
@@ -1,0 +1,20 @@
+package me.kpavlov.mocks.statsd.server
+
+internal data class MetricId(
+    val name: String,
+    val tags: Map<String, String> = emptyMap()
+) {
+    fun matches(wantedName: String, wantedTags: Map<String, String>? = null): Boolean {
+        if (name != wantedName) {
+            return false
+        }
+        return if (wantedTags == null) {
+            true
+        } else if (wantedTags.size > tags.size) {
+            false
+        } else {
+            val commonKeys = wantedTags.keys.intersect(tags.keys)
+            commonKeys.count { tags[it] == wantedTags[it] } == commonKeys.size
+        }
+    }
+}

--- a/src/main/kotlin/me/kpavlov/mocks/statsd/server/StatsDServer.kt
+++ b/src/main/kotlin/me/kpavlov/mocks/statsd/server/StatsDServer.kt
@@ -152,7 +152,7 @@ public open class StatsDServer(port: Int = DEFAULT_PORT) {
     public fun metricContents(
         metricName: String,
         tags: Map<String, String>? = null
-    ): Array<Double>? {
+    ): DoubleArray? {
         val metric = findMetric(metricName, tags)
         return if (metric is Metric.SetMetric) {
             metric.values()

--- a/src/test/kotlin/me/kpavlov/mocks/statsd/server/BaseStatsDServerTest.kt
+++ b/src/test/kotlin/me/kpavlov/mocks/statsd/server/BaseStatsDServerTest.kt
@@ -110,7 +110,7 @@ internal abstract class BaseStatsDServerTest {
         }
 
         assertThat(statsd.metricContents(name))
-            .containsExactlyElementsOf(values.toSet())
+            .containsExactlyInAnyOrder(values.toSet().toTypedArray())
     }
 
     /**

--- a/src/test/kotlin/me/kpavlov/mocks/statsd/server/BaseStatsDServerTest.kt
+++ b/src/test/kotlin/me/kpavlov/mocks/statsd/server/BaseStatsDServerTest.kt
@@ -34,7 +34,8 @@ internal abstract class BaseStatsDServerTest {
         val value = 31L
         client.time(name, value, 0.1)
         await untilAsserted {
-            assertThat(statsd.metric(name)).isEqualTo(value.toDouble())
+            assertThat(statsd.metric(name))
+                .isEqualTo(value.toDouble())
         }
         val expectedMessage = "$name:$value|ms|@0.1"
         assertThat(statsd.calls()).containsOnlyOnce(expectedMessage)
@@ -87,7 +88,8 @@ internal abstract class BaseStatsDServerTest {
         val value = 42.0
         client.gauge(name, value)
         await untilAsserted {
-            assertThat(statsd.metric(name)).isEqualTo(value)
+            assertThat(statsd.metric(name))
+                .isEqualTo(value)
         }
         val expectedMessage = "$name:$value|g"
         assertThat(statsd.calls()).containsOnlyOnce(expectedMessage)

--- a/src/test/kotlin/me/kpavlov/mocks/statsd/server/MetricIdTest.kt
+++ b/src/test/kotlin/me/kpavlov/mocks/statsd/server/MetricIdTest.kt
@@ -1,0 +1,43 @@
+package me.kpavlov.mocks.statsd.server
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class MetricIdTest {
+
+    @Test
+    fun `Name match`() {
+        assertThat(MetricId(name = "name").matches(wantedName = "name"))
+            .isTrue()
+    }
+
+    @Test
+    fun `Name do not match`() {
+        assertThat(MetricId(name = "name").matches(wantedName = "another"))
+            .isFalse()
+    }
+
+    @Test
+    fun `Missing tags do not match`() {
+        assertThat(
+            MetricId(name = "name")
+                .matches(wantedName = "name", wantedTags = mapOf("a" to "b"))
+        ).isFalse()
+    }
+
+    @Test
+    fun `Same tags do match`() {
+        assertThat(
+            MetricId(name = "name", tags = mapOf("a" to "b"))
+                .matches(wantedName = "name", wantedTags = mapOf("a" to "b"))
+        ).isTrue()
+    }
+
+    @Test
+    fun `Less tags do match`() {
+        assertThat(
+            MetricId(name = "name", tags = mapOf("a" to "b", "c" to "d"))
+                .matches(wantedName = "name", wantedTags = mapOf("a" to "b"))
+        ).isTrue()
+    }
+}

--- a/src/test/kotlin/me/kpavlov/mocks/statsd/server/StatsDServerTest.kt
+++ b/src/test/kotlin/me/kpavlov/mocks/statsd/server/StatsDServerTest.kt
@@ -1,8 +1,12 @@
 package me.kpavlov.mocks.statsd.server
 
 import me.kpavlov.mocks.statsd.client.StatsDClient
+import org.assertj.core.api.Assertions.assertThat
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -17,5 +21,56 @@ internal class StatsDServerTest : BaseStatsDServerTest() {
     @AfterAll
     fun afterAll() {
         statsd.stop()
+    }
+
+    @Test
+    fun `Should handle SpringBoot metrics batch`() {
+        val packet = "logback.events:1|c|#statistic:count,level:info\n" +
+            "logback.events:1|c|#statistic:count,level:info\n" +
+            "http.server.requests:75.173334|ms|#error:none,exception:none,method:GET," +
+            "outcome:SUCCESS,status:200,uri:/v2/user/{username}\n" +
+            "http.server.requests:77|ms|#method:GET,status:200 OK,uri:/v2/user/jey\n" +
+            "logback.events:1|c|#statistic:count,level:info\n" +
+            "jvm.buffer.memory.used:46986|g|#statistic:value,id:direct\n" +
+            "jvm.threads.states:0|g|#statistic:value,state:blocked\n" +
+            "process.uptime:4141|g|#statistic:value\n" +
+            "jvm.memory.used:10589472|g|#statistic:value,area:nonheap,id:Compressed Class Space\n" +
+            "jvm.threads.states:17|g|#statistic:value,state:runnable\n" +
+            "system.load.average.1m:4.591797|g|#statistic:value\n" +
+            "jvm.memory.used:73195544|g|#statistic:value,area:nonheap,id:Metaspace\n" +
+            "jvm.buffer.count:0|g|#statistic:value,id:mapped - 'non-volatile memory'\n" +
+            "jvm.memory.committed:54525952|g|#statistic:value,area:heap,id:G1 Old Gen\n" +
+            "r2dbc.pool.max.allocated:10|g|#statistic:value,name:connectionFactory\n" +
+            "jvm.memory.used:4076672|g|#statistic:value,area:nonheap," +
+            "id:CodeHeap 'non-profiled nmethods'\n" +
+            "executor.queue.remaining:2147483647|g|#statistic:value," +
+            "name:applicationTaskExecutor\n" +
+            "jvm.buffer.total.capacity:46985|g|#statistic:value,id:direct\n" +
+            "jvm.memory.committed:88080384|g|#statistic:value,area:heap,id:G1 Eden Space\n" +
+            "executor.pool.size:0|g|#statistic:value,name:applicationTaskExecutor"
+
+        client.send(packet)
+
+        await untilAsserted {
+            assertThat(
+                statsd.metric(
+                    metricName = "jvm.memory.committed",
+                    tags = mapOf(
+                        "id" to "G1 Eden Space",
+                        "statistic" to "value",
+                        "area" to "heap"
+                    )
+                )
+            )
+                .isEqualTo(88080384.0)
+        }
+        await untilAsserted {
+            assertThat(
+                statsd.metric(
+                    metricName = "http.server.requests",
+                    tags = mapOf("uri" to "/v2/user/jey")
+                )
+            ).isEqualTo(77.0)
+        }
     }
 }


### PR DESCRIPTION
# Add initial support for tags

Now it can handle and verify SpringBoot [micrometer statsd registry](https://micrometer.io/docs/registry/statsD) payloads, like:

```
logback.events:1|c|#statistic:count,level:info
http.server.requests:75.173334|ms|#error:none,exception:none,method:GET,outcome:SUCCESS,status:200,uri:/v2/user/{username}
```